### PR TITLE
Fixed random slideshow parameter getting ignored

### DIFF
--- a/web-app/script.js
+++ b/web-app/script.js
@@ -19,10 +19,10 @@ let slideshowId;
  *      - Set a page reload interval for each hour
  */
 window.addEventListener('load', () => {
+    forceRandomSlideshow = shouldOnlyPlayRandom();
     initSlideshow();
     loadWeatherInformation();
     initHideButton();
-    forceRandomSlideshow = shouldOnlyPlayRandom();
 
     // Reload page every x minutes
     let refreshIntervalInMinutes = getRefreshInterval();


### PR DESCRIPTION
I had the problem that no random slideshows were running on my device after an update. Moved the random check to the start of init, because previously it gets called after the decision gets made if this week should be shown or if a random slideshow should be shown.