### PR TITLE
Make slideshow display in full screen when added as a webapp to the homescreen in iOS. 

### DIFF
--- a/web-app/index.html
+++ b/web-app/index.html
@@ -5,6 +5,10 @@
     <link href="style.css" rel="stylesheet" type="text/css"/>
     <script src="script.js"></script>
     <meta charset="UTF-8">
+    <meta name="viewport" content="target-densitydpi=device-dpi, width=device-width, user-scalable=no, maximum-scale=1.0, minimum-scale=1.0" />
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <link rel="icon" type="image/png" href="icon.png">
 </head>
 <body>


### PR DESCRIPTION
Add meta flags required to allow the web-app to be shown in full screen in iOS after being added to the homescreen as a bookmark. 