### PR TITLE
chore(deps): update SQLite dependencies (combined)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,9 +1321,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1714,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "r2d2_sqlite"
-version = "0.26.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee025287c0188d75ae2563bcb91c9b0d1843cfc56e4bd3ab867597971b5cc256"
+checksum = "63417e83dc891797eea3ad379f52a5986da4bca0d6ef28baf4d14034dd111b0c"
 dependencies = [
  "r2d2",
  "rusqlite",
@@ -1934,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.33.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags 2.8.0",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ env_logger = "0.11.3"
 rand = "0.9.0"
 mime_guess = "2.0.5"
 r2d2 = "0.8.10"
-rusqlite = { version = "0.33", features = ["bundled"] }
-r2d2_sqlite = "0.26"
+rusqlite = { version = "0.37", features = ["bundled"] }
+r2d2_sqlite = "0.31"
 
 [dev-dependencies]
 assertor = "0.0.4"


### PR DESCRIPTION
## Summary

This PR combines the SQLite dependency updates from PRs #166 and #167 to resolve version conflicts:

- Updates `rusqlite` from 0.33 to 0.37
- Updates `r2d2_sqlite` from 0.26 to 0.31

## Background

The individual PRs couldn't be merged separately due to conflicting `libsqlite3-sys` dependencies:
- `rusqlite` 0.37 requires `libsqlite3-sys` 0.35.0
- `r2d2_sqlite` 0.26 depends on `rusqlite` 0.33 which uses `libsqlite3-sys` 0.31.0

Both crates link to the native `sqlite3` library, causing a conflict when updated separately.

## Changes

- ✅ Code compiles successfully
- ✅ Tests pass (same test failures as main branch, unrelated to SQLite updates)
- ✅ Code formatting and linting checks pass
- ✅ Dependencies resolve without conflicts

This PR supersedes #166 and #167.