### PR TITLE
Tech-debt cleanup: indexing panics, 404 contract, code hygiene, audit report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
@@ -2165,15 +2165,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.10",
  "rustls-pki-types",
@@ -2628,7 +2631,7 @@ dependencies = [
  "flate2",
  "log",
  "percent-encoding",
- "rustls 0.23.23",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,12 +732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,16 +1811,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2423,6 @@ dependencies = [
  "md5",
  "mimalloc",
  "mime_guess",
- "pretty_assertions",
  "r2d2",
  "r2d2_sqlite",
  "rand 0.10.1",
@@ -3201,12 +3184,6 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ mimalloc = "0.1.43"
 
 [dev-dependencies]
 assertor = "0.0.4"
-pretty_assertions = "1.4"
 actix-rt = "2.9"
 ureq = "3.0.0"
 

--- a/TECH_DEBT_AUDIT.md
+++ b/TECH_DEBT_AUDIT.md
@@ -5,7 +5,7 @@ Audit run: 2026-08-02 · Depth: standard · Status: first run (no prior report)
 ## Executive summary
 
 - **Fixed this run (7 findings):** indexing panics on unreadable files, 3 clippy warnings, unused dev-dependency + dead code, 500→404 on missing resource metadata, brittle byte-count test, blocking HTTP inside async handlers, and 5 synchronous XHRs on the frontend main thread.
-- **Biggest remaining:** resource IDs are `md5(file_name)` (`src/filesystem_client.rs:179`) — same-named files in different folders silently collide and one replaces the other. Needs a deliberate id-scheme decision + migration; not fixable as a mechanical cleanup.
+- **Biggest remaining:** resource IDs are `md5(file_name)` (`src/filesystem_client.rs:198`) — same-named files in different folders silently collide and one replaces the other. Needs a deliberate id-scheme decision + migration; not fixable as a mechanical cleanup.
 - **`spec.md` (approved 2026-06-13, memory-optimization) is untracked and unimplemented.** The code has no size-bounded LRU cache, no reduced-resolution decode, no streaming indexing. Maintainer confirmed superseded/abandoned — recommend deleting or re-scoping the file.
 - **Verification gates** (from CI, `.github/workflows/build-image.yaml`): `cargo fmt --all -- --check`, `cargo clippy`, `cargo test`. All green (test suite needs the two API-key secrets that CI injects — see below).
 - Per maintainer decision: no `AGENTS.md` was created this run; learnings are in the "Learnings" section of this report instead.
@@ -18,31 +18,31 @@ Actix-web HTTP server (Rust 2021, `src/main.rs`) serving a single-page slideshow
 
 | ID | Category | File:Line | Severity | Effort | Status | Description | Recommendation |
 |---|---|---|---|---|---|---|---|
-| FIX-1 | Error handling | `src/filesystem_client.rs:27,44,55,92,112,121,151,194` | High | S | **FIXED** | 8 panic sites in the indexing path; one unreadable file killed the background index thread silently (stale/empty store until midnight retry) | Log-and-skip each unreadable entry instead of panicking |
-| QW-2 | Hygiene | `src/image_processor.rs:33`, `src/integration_test_resources_api.rs:13`, `src/integration_test_config_api.rs:77`, `src/integration_test_weather_api.rs:102` | Low | S | **FIXED** | 4 clippy warnings (`unnecessary_unwrap`, unused import, 2× `useless_borrows_in_formatting`) | Fixed |
-| QW-1 | Dead code/deps | `Cargo.toml:39`, `src/resource_reader.rs:40`, `src/main.rs:1` | Low | S | **FIXED** | `pretty_assertions` dev-dep never imported; `ImageResource::with_taken_date` 0 call sites; `extern crate core` noise | Removed |
-| QW-3 | Contract | `src/resource_endpoint.rs:186,202` | Med | S | **FIXED** | Missing resource returned 500 where sibling endpoints return 404 | Return `NotFound` |
-| QW-4 | Test debt | `src/integration_test_resources_api.rs:366` | Med | S | **FIXED** | `assert_that!(response.len()).is_equal_to(316)` pinned exact PNG encoder output; breaks on image-crate bumps | Structural assertion (PNG magic + fits-in-bounds) |
-| ARCH-1 | Async/blocking | `src/weather_processor.rs:16,40`, `src/geo_location.rs:146` | Med | M | **FIXED** | Blocking `ureq::call()` on actix worker threads, no timeouts | `web::block` + 15 s global timeout |
-| FRONT-1 | Frontend perf | `web-app/script.js:43,55,252,361,374` (+ per-tick config refetch) | Med | M | **FIXED** | 5 synchronous XHRs blocked the main thread; preload config was re-fetched on every slideshow tick | One-time async config load at startup; all consumers read the cache |
-| ID-1 | Correctness | `src/filesystem_client.rs:179` (id), `src/scheduler.rs:52` (HashMap dedupe), `src/resource_store.rs:332` (`INSERT OR REPLACE`) | High | L | NEW | Resource id = `md5(file_name)` → same-named files in different folders collide; one silently replaces the other; hide affects all copies | Deliberate id-scheme decision (path-based id + migration of `resources`/`hidden`/`data_cache`) — see Top 5 |
-| SPEC-1 | Doc drift | `spec.md` (untracked, approved 2026-06-13) vs `src/resource_store.rs:354`, `src/image_processor.rs:30`, `src/scheduler.rs:52` | High | L | RESOLVED | Approved memory-optimization spec never implemented; code has no bounded cache/LRU, no reduced-resolution decode, no streaming indexing | Maintainer confirmed superseded; delete or re-scope the file |
-| PERF-1 | Performance | `src/image_processor.rs:64` (PNG transcode), `:30` (full decode), `src/resource_store.rs:354` (unbounded cache) | Med | L | NEW | Photographic sources re-encoded as PNG (3–10× larger than JPEG), decoded at full resolution, cached without bound | Revisit when SPEC-1 is decided; FR-002/FR-005 describe the target |
+| FIX-1 | Error handling | `src/filesystem_client.rs:20,31,48,96,113,122,156,163,171,219` | High | S | **FIXED** | 8 panic sites in the indexing path; one unreadable file killed the background index thread silently (stale/empty store until midnight retry) | Log-and-skip each unreadable entry instead of panicking |
+| QW-2 | Hygiene | `src/image_processor.rs:35`, `src/integration_test_resources_api.rs:10`, `src/integration_test_config_api.rs:77`, `src/integration_test_weather_api.rs:102` | Low | S | **FIXED** | 4 clippy warnings (`unnecessary_unwrap`, unused import, 2× `useless_borrows_in_formatting`) | Fixed |
+| QW-1 | Dead code/deps | `Cargo.toml:37`, `src/resource_reader.rs:29`, `src/main.rs:1` | Low | S | **FIXED** | `pretty_assertions` dev-dep never imported; `ImageResource::with_taken_date` 0 call sites; `extern crate core` noise | Removed |
+| QW-3 | Contract | `src/resource_endpoint.rs:202,223` | Med | S | **FIXED** | Missing resource returned 500 where sibling endpoints return 404 | Return `NotFound` |
+| QW-4 | Test debt | `src/integration_test_resources_api.rs:336` | Med | S | **FIXED** | `assert_that!(response.len()).is_equal_to(316)` pinned exact PNG encoder output; breaks on image-crate bumps | Structural assertion (PNG magic + fits-in-bounds) |
+| ARCH-1 | Async/blocking | `src/weather_processor.rs:25,56`, `src/geo_location.rs:150` | Med | M | **FIXED** | Blocking `ureq::call()` on actix worker threads, no timeouts | `web::block` + 15 s global timeout |
+| FRONT-1 | Frontend perf | `web-app/script.js:52,237,345,365` (+ per-tick config refetch) | Med | M | **FIXED** | 5 synchronous XHRs blocked the main thread; preload config was re-fetched on every slideshow tick | One-time async config load at startup; all consumers read the cache |
+| ID-1 | Correctness | `src/filesystem_client.rs:198` (id), `src/scheduler.rs:52` (HashMap dedupe), `src/resource_store.rs:232` (`INSERT OR REPLACE`) | High | L | NEW | Resource id = `md5(file_name)` → same-named files in different folders collide; one silently replaces the other; hide affects all copies | Deliberate id-scheme decision (path-based id + migration of `resources`/`hidden`/`data_cache`) — see Top 5 |
+| SPEC-1 | Doc drift | `spec.md` (untracked, approved 2026-06-13) vs `src/resource_store.rs:354`, `src/image_processor.rs:35`, `src/scheduler.rs:52` | High | L | RESOLVED | Approved memory-optimization spec never implemented; code has no bounded cache/LRU, no reduced-resolution decode, no streaming indexing | Maintainer confirmed superseded; delete or re-scope the file |
+| PERF-1 | Performance | `src/image_processor.rs:70,35` (PNG transcode/full decode), `src/resource_store.rs:354` (unbounded cache) | Med | L | NEW | Photographic sources re-encoded as PNG (3–10× larger than JPEG), decoded at full resolution, cached without bound | Revisit when SPEC-1 is decided; FR-002/FR-005 describe the target |
 | ERR-2 | Error handling | `src/resource_store.rs:128,248` (`"failed:n"` typo, panic on DB error in request path), `:423` (query errors silently truncate results) | Med | M | NEW | All DB ops `panic!`/`unwrap`; a DB failure inside a request handler kills the request; `execute_query` silently returns partial lists on SQL errors | Return `Result` from store methods used by handlers; fix the typo; log-and-stop on query error |
-| PERF-4 | Performance | `src/resource_store.rs:64,87` (json_each full scan over every resource per week query) | Med | L | NEW | Week/count queries JSON-parse every row with `json_each` — O(N) per slideshow refresh for 90k+ libraries | Denormalize `taken` into a column + index; part of the SPEC-1 territory |
+| PERF-4 | Performance | `src/resource_store.rs:63,94` (json_each full scan over every resource per week query) | Med | L | NEW | Week/count queries JSON-parse every row with `json_each` — O(N) per slideshow refresh for 90k+ libraries | Denormalize `taken` into a column + index; part of the SPEC-1 territory |
 | CHG-1 | Docs | `.releaserc` (`chore` → patch) + 1305-line `CHANGELOG.md` of near-empty stanzas | Low | S | NEW | Renovate dep bumps generate empty release entries | Group dep bumps with `skip ci` or restrict `chore` release rule; cosmetic |
 | — | Test infra | `src/resource_processor_test.rs`, `src/integration_test_weather_api.rs` | Low | — | REJECTED | 6 tests require live API keys + internet (`BIGDATA_CLOUD_API_KEY`, `OPEN_WEATHER_MAP_API_KEY`) | Deliberate: CI injects both secrets (`build-image.yaml` test job). Local `cargo test` without keys fails these 6 — documented, not a bug |
 | — | Deps | `kamadak-exif` (cargo machete) | — | — | REJECTED | machete flags it unused; false positive — crate lib name is `exif` (`src/exif_reader.rs:2` uses `exif::Exif`) | Ignore |
 
 ## Fixed this run
 
-**FIX-1 — indexing no longer panics on unreadable files.** Replaced 8 `panic!` sites in `src/filesystem_client.rs` with log-and-skip: metadata/read_dir failures on folders (`:27,44,55`), non-UTF8 folder names (`:92`), ignore-marker scan failures (`:112,121`), unreadable files and metadata during resource reads (`:151,153`), and exif-open failures (`:194`, returns the resource without exif metadata). Tests added in `src/resource_reader_test.rs`: `read_dir_with_unreadable_file_does_not_panic` (chmod-000 file, skipped when euid 0) and `fill_exif_data_missing_file_does_not_panic`. Both failed on the pre-fix code (red), pass after.
+**FIX-1 — indexing no longer panics on unreadable files.** Replaced 8 `panic!` sites in `src/filesystem_client.rs` with log-and-skip: metadata/read_dir failures on folders (`:20,31,48`), non-UTF8 folder names (`:96`), ignore-marker scan failures (`:113,122`), unreadable files and metadata during resource reads (`:156,163,171`), and exif-open failures (`:219`, returns the resource without exif metadata). Tests added in `src/resource_reader_test.rs`: `read_dir_with_unreadable_file_does_not_panic` (chmod-000 file, skipped when euid 0) and `fill_exif_data_missing_file_does_not_panic`. Both failed on the pre-fix code (red), pass after. Follow-up this run: non-UTF8 file names and unreadable mtimes are now skipped instead of panicking (same let-else/log-and-skip pattern, `:156` and the `modified()` fallback at `:206`), and the per-entry skip logs were raised `debug!` → `warn!` so silently dropped files are visible at the shipped `RUST_LOG=info`. Regression test `read_dir_with_non_utf8_file_name_does_not_panic` (non-UTF8 name via `OsString::from_vec`, skipped when euid 0) panicked on the pre-fix code, passes after.
 
-**QW-1/QW-2 — hygiene.** Removed `pretty_assertions` dev-dep (`Cargo.toml`, 23 lines pruned from `Cargo.lock`), dead `with_taken_date` (`src/resource_reader.rs`), `extern crate core` (`src/main.rs`); fixed `unnecessary_unwrap` (`src/image_processor.rs:33`), unused `FallibleIterator` import, and two `useless_borrows_in_formatting` (`src/integration_test_config_api.rs`, `src/integration_test_weather_api.rs`). Clippy: 4 warnings → 0.
+**QW-1/QW-2 — hygiene.** Removed `pretty_assertions` dev-dep (`Cargo.toml`, 23 lines pruned from `Cargo.lock`), dead `with_taken_date` (`src/resource_reader.rs`), `extern crate core` (`src/main.rs`); fixed `unnecessary_unwrap` (`src/image_processor.rs:27,35`), unused `FallibleIterator` import, and two `useless_borrows_in_formatting` (`src/integration_test_config_api.rs`, `src/integration_test_weather_api.rs`). Clippy: 4 warnings → 0.
 
-**QW-3 — correct status codes.** `get_resource_metadata_by_id` and `get_resource_metadata_description_by_id` now return 404 for unknown ids (`src/resource_endpoint.rs:186,202`), matching `get_resource_by_id_and_resolution`.
+**QW-3 — correct status codes.** `get_resource_metadata_by_id` and `get_resource_metadata_description_by_id` now return 404 for unknown ids (`src/resource_endpoint.rs:202,223`), matching `get_resource_by_id_and_resolution`. Regression test `test_get_unknown_resource_metadata_returns_not_found` (`src/integration_test_resources_api.rs:428`) pins 404 for unknown ids on both endpoints.
 
-**QW-4 — robust image test.** Replaced the exact byte count with: PNG magic byte + decode header dimensions fit within the requested bounds and are non-degenerate (`src/integration_test_resources_api.rs:366`). This surfaced that `adjust_image` is *aspect-preserving* (`DynamicImage::resize`, `image-0.25.10/src/images/dynimage.rs:873`), which is correct for the `object-fit: contain` render path.
+**QW-4 — robust image test.** Replaced the exact byte count with: PNG magic byte + decode header dimensions fit within the requested bounds and are non-degenerate (`src/integration_test_resources_api.rs:336`). This surfaced that `adjust_image` is *aspect-preserving* (`DynamicImage::resize`, `image-0.25.10/src/images/dynimage.rs:873`), which is correct for the `object-fit: contain` render path.
 
 **ARCH-1 — no blocking HTTP on worker threads.** `get_current_weather`, `get_home_assistant_data` (`src/weather_processor.rs`) and `resolve_city_name` (`src/geo_location.rs`) now run their `ureq` calls inside `actix_web::web::block` with a 15 s global timeout (`ureq::RequestBuilder::config().timeout_global`).
 
@@ -53,10 +53,11 @@ Actix-web HTTP server (Rust 2021, `src/main.rs`) serving a single-page slideshow
 ```
 cargo fmt --all -- --check   → clean
 cargo clippy --all-targets   → 0 warnings
-cargo test                   → 25 passed; 6 failed (all pre-existing, key-gated:
+cargo test                   → 27 passed; 6 failed (all pre-existing, key-gated:
                                4× resolve_* need BIGDATA_CLOUD_API_KEY,
                                test_get_weather_current needs OPEN_WEATHER_MAP_API_KEY,
-                               description test needs geo key — CI injects both)
+                               description test needs geo key — CI injects both;
+                               all 33 pass with both keys exported)
 node --check web-app/script.js → OK
 ```
 
@@ -64,15 +65,15 @@ Live smoke (debug binary, 2-image library): `/api/health` 200; indexing complete
 
 ## Top 5 remaining
 
-1. **ID-1 — resource id collisions (`src/filesystem_client.rs:179`).** Two `IMG_0001.jpg` in different folders → identical `md5(file_name)` → `HashMap` dedupe (`src/scheduler.rs:52`) + `INSERT OR REPLACE` (`src/resource_store.rs:332`) silently drop one; hiding one hides both. Impact grows with library size. Fix: hash the full path (or path+name), migrate persisted ids in `resources`, `hidden`, `data_cache` on startup, update tests that pin `md5(file_name)` (`src/resource_reader_test.rs:90,129,151,172`). Requires the maintainer to pick the scheme — it changes URL contracts and persisted data.
+1. **ID-1 — resource id collisions (`src/filesystem_client.rs:198`).** Two `IMG_0001.jpg` in different folders → identical `md5(file_name)` → `HashMap` dedupe (`src/scheduler.rs:52`) + `INSERT OR REPLACE` (`src/resource_store.rs:232`) silently drop one; hiding one hides both. Impact grows with library size. Fix: hash the full path (or path+name), migrate persisted ids in `resources`, `hidden`, `data_cache` on startup, update tests that pin `md5(file_name)` (`src/resource_reader_test.rs:49,106,127`). Requires the maintainer to pick the scheme — it changes URL contracts and persisted data.
 
 2. **SPEC-1 — decide the memory-optimization spec.** `spec.md` is approved but unimplemented and now untracked. Either delete it (superseded) or re-scope and plan it; currently it silently misdescribes the codebase to anyone who reads it.
 
 3. **ERR-2 — store error handling (`src/resource_store.rs`).** Every DB operation panics or unwraps; request-path failures (e.g. `add_data_cache_entry` during image serving) crash the request. `execute_query` stops silently on SQL error, returning a partial list. Fix: `Result`-returning methods on the two request-path functions first, log-and-continue in `execute_query`, fix the `"failed:n"` typo at `:128,248`.
 
-4. **PERF-1 — image pipeline (`src/image_processor.rs:30,64`, `src/resource_store.rs:354`).** Full-resolution decode → PNG re-encode → unbounded BLOB cache. This is the 400 MB RSS story the spec was written to fix; only actionable once SPEC-1's direction is settled.
+4. **PERF-1 — image pipeline (`src/image_processor.rs:35,70`, `src/resource_store.rs:354`).** Full-resolution decode → PNG re-encode → unbounded BLOB cache. This is the 400 MB RSS story the spec was written to fix; only actionable once SPEC-1's direction is settled.
 
-5. **PERF-4 — week-query cost (`src/resource_store.rs:64,87`).** `json_each` full-scan + `strftime` comparison over every resource on each `/api/resources/week` request. Denormalize `taken` into a queryable column with an index once the schema is touched.
+5. **PERF-4 — week-query cost (`src/resource_store.rs:63,94`).** `json_each` full-scan + `strftime` comparison over every resource on each `/api/resources/week` request. Denormalize `taken` into a queryable column with an index once the schema is touched.
 
 ## Quick wins
 

--- a/TECH_DEBT_AUDIT.md
+++ b/TECH_DEBT_AUDIT.md
@@ -1,0 +1,119 @@
+# Tech Debt Audit — this-week-in-past
+
+Audit run: 2026-08-02 · Depth: standard · Status: first run (no prior report)
+
+## Executive summary
+
+- **Fixed this run (7 findings):** indexing panics on unreadable files, 3 clippy warnings, unused dev-dependency + dead code, 500→404 on missing resource metadata, brittle byte-count test, blocking HTTP inside async handlers, and 5 synchronous XHRs on the frontend main thread.
+- **Biggest remaining:** resource IDs are `md5(file_name)` (`src/filesystem_client.rs:179`) — same-named files in different folders silently collide and one replaces the other. Needs a deliberate id-scheme decision + migration; not fixable as a mechanical cleanup.
+- **`spec.md` (approved 2026-06-13, memory-optimization) is untracked and unimplemented.** The code has no size-bounded LRU cache, no reduced-resolution decode, no streaming indexing. Maintainer confirmed superseded/abandoned — recommend deleting or re-scoping the file.
+- **Verification gates** (from CI, `.github/workflows/build-image.yaml`): `cargo fmt --all -- --check`, `cargo clippy`, `cargo test`. All green (test suite needs the two API-key secrets that CI injects — see below).
+- Per maintainer decision: no `AGENTS.md` was created this run; learnings are in the "Learnings" section of this report instead.
+
+## Architectural mental model
+
+Actix-web HTTP server (Rust 2021, `src/main.rs`) serving a single-page slideshow (`web-app/`). At startup and at midnight (`src/scheduler.rs`) a background thread walks the configured `RESOURCE_PATHS`, extracts EXIF metadata per file (date taken, GPS, orientation), and writes id→JSON rows into a SQLite database (`resources` table). The slideshow frontend asks for this-week resource ids, then requests each photo as `/api/resources/{id}/{w}/{h}`; the handler decodes the source file fully, applies EXIF rotation, aspect-preserves it into the display bounds, encodes PNG, and stores the result in an unbounded `data_cache` BLOB table. Weather/geo city-name lookups hit external HTTPS APIs on demand. Everything is configured through env vars; the Docker image is a scratch container with a musl build.
+
+## Findings table
+
+| ID | Category | File:Line | Severity | Effort | Status | Description | Recommendation |
+|---|---|---|---|---|---|---|---|
+| FIX-1 | Error handling | `src/filesystem_client.rs:27,44,55,92,112,121,151,194` | High | S | **FIXED** | 8 panic sites in the indexing path; one unreadable file killed the background index thread silently (stale/empty store until midnight retry) | Log-and-skip each unreadable entry instead of panicking |
+| QW-2 | Hygiene | `src/image_processor.rs:33`, `src/integration_test_resources_api.rs:13`, `src/integration_test_config_api.rs:77`, `src/integration_test_weather_api.rs:102` | Low | S | **FIXED** | 4 clippy warnings (`unnecessary_unwrap`, unused import, 2× `useless_borrows_in_formatting`) | Fixed |
+| QW-1 | Dead code/deps | `Cargo.toml:39`, `src/resource_reader.rs:40`, `src/main.rs:1` | Low | S | **FIXED** | `pretty_assertions` dev-dep never imported; `ImageResource::with_taken_date` 0 call sites; `extern crate core` noise | Removed |
+| QW-3 | Contract | `src/resource_endpoint.rs:186,202` | Med | S | **FIXED** | Missing resource returned 500 where sibling endpoints return 404 | Return `NotFound` |
+| QW-4 | Test debt | `src/integration_test_resources_api.rs:366` | Med | S | **FIXED** | `assert_that!(response.len()).is_equal_to(316)` pinned exact PNG encoder output; breaks on image-crate bumps | Structural assertion (PNG magic + fits-in-bounds) |
+| ARCH-1 | Async/blocking | `src/weather_processor.rs:16,40`, `src/geo_location.rs:146` | Med | M | **FIXED** | Blocking `ureq::call()` on actix worker threads, no timeouts | `web::block` + 15 s global timeout |
+| FRONT-1 | Frontend perf | `web-app/script.js:43,55,252,361,374` (+ per-tick config refetch) | Med | M | **FIXED** | 5 synchronous XHRs blocked the main thread; preload config was re-fetched on every slideshow tick | One-time async config load at startup; all consumers read the cache |
+| ID-1 | Correctness | `src/filesystem_client.rs:179` (id), `src/scheduler.rs:52` (HashMap dedupe), `src/resource_store.rs:332` (`INSERT OR REPLACE`) | High | L | NEW | Resource id = `md5(file_name)` → same-named files in different folders collide; one silently replaces the other; hide affects all copies | Deliberate id-scheme decision (path-based id + migration of `resources`/`hidden`/`data_cache`) — see Top 5 |
+| SPEC-1 | Doc drift | `spec.md` (untracked, approved 2026-06-13) vs `src/resource_store.rs:354`, `src/image_processor.rs:30`, `src/scheduler.rs:52` | High | L | RESOLVED | Approved memory-optimization spec never implemented; code has no bounded cache/LRU, no reduced-resolution decode, no streaming indexing | Maintainer confirmed superseded; delete or re-scope the file |
+| PERF-1 | Performance | `src/image_processor.rs:64` (PNG transcode), `:30` (full decode), `src/resource_store.rs:354` (unbounded cache) | Med | L | NEW | Photographic sources re-encoded as PNG (3–10× larger than JPEG), decoded at full resolution, cached without bound | Revisit when SPEC-1 is decided; FR-002/FR-005 describe the target |
+| ERR-2 | Error handling | `src/resource_store.rs:128,248` (`"failed:n"` typo, panic on DB error in request path), `:423` (query errors silently truncate results) | Med | M | NEW | All DB ops `panic!`/`unwrap`; a DB failure inside a request handler kills the request; `execute_query` silently returns partial lists on SQL errors | Return `Result` from store methods used by handlers; fix the typo; log-and-stop on query error |
+| PERF-4 | Performance | `src/resource_store.rs:64,87` (json_each full scan over every resource per week query) | Med | L | NEW | Week/count queries JSON-parse every row with `json_each` — O(N) per slideshow refresh for 90k+ libraries | Denormalize `taken` into a column + index; part of the SPEC-1 territory |
+| CHG-1 | Docs | `.releaserc` (`chore` → patch) + 1305-line `CHANGELOG.md` of near-empty stanzas | Low | S | NEW | Renovate dep bumps generate empty release entries | Group dep bumps with `skip ci` or restrict `chore` release rule; cosmetic |
+| — | Test infra | `src/resource_processor_test.rs`, `src/integration_test_weather_api.rs` | Low | — | REJECTED | 6 tests require live API keys + internet (`BIGDATA_CLOUD_API_KEY`, `OPEN_WEATHER_MAP_API_KEY`) | Deliberate: CI injects both secrets (`build-image.yaml` test job). Local `cargo test` without keys fails these 6 — documented, not a bug |
+| — | Deps | `kamadak-exif` (cargo machete) | — | — | REJECTED | machete flags it unused; false positive — crate lib name is `exif` (`src/exif_reader.rs:2` uses `exif::Exif`) | Ignore |
+
+## Fixed this run
+
+**FIX-1 — indexing no longer panics on unreadable files.** Replaced 8 `panic!` sites in `src/filesystem_client.rs` with log-and-skip: metadata/read_dir failures on folders (`:27,44,55`), non-UTF8 folder names (`:92`), ignore-marker scan failures (`:112,121`), unreadable files and metadata during resource reads (`:151,153`), and exif-open failures (`:194`, returns the resource without exif metadata). Tests added in `src/resource_reader_test.rs`: `read_dir_with_unreadable_file_does_not_panic` (chmod-000 file, skipped when euid 0) and `fill_exif_data_missing_file_does_not_panic`. Both failed on the pre-fix code (red), pass after.
+
+**QW-1/QW-2 — hygiene.** Removed `pretty_assertions` dev-dep (`Cargo.toml`, 23 lines pruned from `Cargo.lock`), dead `with_taken_date` (`src/resource_reader.rs`), `extern crate core` (`src/main.rs`); fixed `unnecessary_unwrap` (`src/image_processor.rs:33`), unused `FallibleIterator` import, and two `useless_borrows_in_formatting` (`src/integration_test_config_api.rs`, `src/integration_test_weather_api.rs`). Clippy: 4 warnings → 0.
+
+**QW-3 — correct status codes.** `get_resource_metadata_by_id` and `get_resource_metadata_description_by_id` now return 404 for unknown ids (`src/resource_endpoint.rs:186,202`), matching `get_resource_by_id_and_resolution`.
+
+**QW-4 — robust image test.** Replaced the exact byte count with: PNG magic byte + decode header dimensions fit within the requested bounds and are non-degenerate (`src/integration_test_resources_api.rs:366`). This surfaced that `adjust_image` is *aspect-preserving* (`DynamicImage::resize`, `image-0.25.10/src/images/dynimage.rs:873`), which is correct for the `object-fit: contain` render path.
+
+**ARCH-1 — no blocking HTTP on worker threads.** `get_current_weather`, `get_home_assistant_data` (`src/weather_processor.rs`) and `resolve_city_name` (`src/geo_location.rs`) now run their `ureq` calls inside `actix_web::web::block` with a 15 s global timeout (`ureq::RequestBuilder::config().timeout_global`).
+
+**FRONT-1 — sync XHRs removed.** `web-app/script.js`: new one-time `loadAppConfig()` (async fetch, URL params take precedence) cached in `appConfig`; deleted `shouldOnlyPlayRandom`, `shouldPreloadImages`, `getSlideshowInterval`, `getRefreshInterval`; `getCurrentTemperatureDataFromHomeAssistant` is now async; removed the per-tick preload-config refetch. 5 sync XHRs → 0.
+
+**Verification evidence**
+
+```
+cargo fmt --all -- --check   → clean
+cargo clippy --all-targets   → 0 warnings
+cargo test                   → 25 passed; 6 failed (all pre-existing, key-gated:
+                               4× resolve_* need BIGDATA_CLOUD_API_KEY,
+                               test_get_weather_current needs OPEN_WEATHER_MAP_API_KEY,
+                               description test needs geo key — CI injects both)
+node --check web-app/script.js → OK
+```
+
+Live smoke (debug binary, 2-image library): `/api/health` 200; indexing completed (2 resources); image endpoint 200, PNG 10×7; missing metadata → 404; hide/unhide 200/200. Browser (headless Chromium): page loads with zero console errors, image renders through the async config → playlist → image chain, `?SHOW_HIDE_BUTTON=true` URL override honored.
+
+## Top 5 remaining
+
+1. **ID-1 — resource id collisions (`src/filesystem_client.rs:179`).** Two `IMG_0001.jpg` in different folders → identical `md5(file_name)` → `HashMap` dedupe (`src/scheduler.rs:52`) + `INSERT OR REPLACE` (`src/resource_store.rs:332`) silently drop one; hiding one hides both. Impact grows with library size. Fix: hash the full path (or path+name), migrate persisted ids in `resources`, `hidden`, `data_cache` on startup, update tests that pin `md5(file_name)` (`src/resource_reader_test.rs:90,129,151,172`). Requires the maintainer to pick the scheme — it changes URL contracts and persisted data.
+
+2. **SPEC-1 — decide the memory-optimization spec.** `spec.md` is approved but unimplemented and now untracked. Either delete it (superseded) or re-scope and plan it; currently it silently misdescribes the codebase to anyone who reads it.
+
+3. **ERR-2 — store error handling (`src/resource_store.rs`).** Every DB operation panics or unwraps; request-path failures (e.g. `add_data_cache_entry` during image serving) crash the request. `execute_query` stops silently on SQL error, returning a partial list. Fix: `Result`-returning methods on the two request-path functions first, log-and-continue in `execute_query`, fix the `"failed:n"` typo at `:128,248`.
+
+4. **PERF-1 — image pipeline (`src/image_processor.rs:30,64`, `src/resource_store.rs:354`).** Full-resolution decode → PNG re-encode → unbounded BLOB cache. This is the 400 MB RSS story the spec was written to fix; only actionable once SPEC-1's direction is settled.
+
+5. **PERF-4 — week-query cost (`src/resource_store.rs:64,87`).** `json_each` full-scan + `strftime` comparison over every resource on each `/api/resources/week` request. Denormalize `taken` into a queryable column with an index once the schema is touched.
+
+## Quick wins
+
+- [ ] Delete or re-scope `spec.md` (untracked approved spec, confirmed superseded) — or `git add` it if it stays live.
+- [ ] Fix `"failed:n"` → `"failed:\n"` panic messages (`src/resource_store.rs:128,248`).
+- [ ] Add a `RESOURCE_PATHS`/`DATA_FOLDER` + test-keys note to `README.md` so `cargo test` is runnable locally (documented in CI only today).
+- [ ] Investigate `localityLanguage=de` hardcode (`src/geo_location.rs:143`) — city names are always German regardless of `WEATHER_LANGUAGE`.
+- [ ] Consider dropping the `chore`→patch release rule (`.releaserc`) or batching renovate bumps to stop empty CHANGELOG stanzas.
+
+## Things that look bad but are actually fine
+
+- **`kamadak-exif` "unused" per cargo machete** — false positive; lib name is `exif`.
+- **Tests hit live network/external APIs** — deliberate; CI injects the two API keys, `resource_reader_test.rs` downloads fixtures from w3.org/github on every run. Flaky-by-design but an accepted convention here.
+- **Aspect-preserving resize vs. requested exact dimensions** — `DynamicImage::resize` preserves aspect ratio; `#slideshow-image { object-fit: contain }` (`web-app/style.css`) makes that the correct contract. Not distortion.
+- **Emoji-prefixed log messages** (`src/main.rs`, `src/scheduler.rs`) — consistent style across the repo, harmless.
+- **`week/image` endpoint unused by the frontend** — plausible external/legacy client surface; not removed.
+- **`CACHE_DIR` deprecated-but-honored** (`src/main.rs:66`) — documented in the code path and README; intentional migration path.
+- **Panic on missing `RESOURCE_PATHS` / non-existent resource folder** (`src/main.rs:60`, `src/resource_reader.rs:110`) — fail-fast on misconfiguration, reasonable for a single-user self-hosted app.
+- **API key in bigdatacloud query string** (`src/geo_location.rs:137`) — API-design requirement, HTTPS transport; not a leak vector in this codebase.
+
+## Open questions for the maintainer
+
+1. **spec.md** — delete, re-scope, or resurrect? (Marked superseded this run; file still on disk, untracked.)
+2. **Resource id scheme** — is `md5(file_name)` intentional (stable ids across folder moves)? The collision behavior is almost certainly unintended for multi-folder libraries.
+3. **`localityLanguage=de`** (`src/geo_location.rs:143`) — intentional hardcode or should it follow `WEATHER_LANGUAGE`?
+4. **`week/image` endpoint** — still needed by any client?
+5. **Local test workflow** — worth documenting the two API keys in the README so contributors can run the full suite locally?
+
+## Not audited
+
+- `.github/workflows/scripts/*` (prep-build-env, arch translation, asset upload) and `.container/stage-arch-bin.sh` — release plumbing, touched only by release automation.
+- `web-app/index.html` and `web-app/style.css` beyond the slideshow-image/contain check — cosmetic surface.
+- `docker-compose.yaml`, `renovate.json`, `Containerfile` — read, but no deep review of image layering or renovate config.
+- Third-party API response handling (OpenWeatherMap/Home Assistant/bigdatacloud payload shapes) — exercised indirectly via tests/smoke only.
+- No security tooling ran: `cargo audit`/Trivy run in CI (`.github/workflows/scheduled-security-audit.yaml`); not installed locally this run.
+
+## Learnings (durable, for the next agent)
+
+- `cargo test` fails 6 tests without `BIGDATA_CLOUD_API_KEY` and `OPEN_WEATHER_MAP_API_KEY` — that is the expected baseline, not a regression; CI injects both secrets.
+- Resource ids are `md5(file_name)` and are load-bearing: they appear in URLs, the `hidden` table, and `data_cache` keys. Do not change the derivation without a migration.
+- `adjust_image` is aspect-preserving by design and the frontend relies on it (`object-fit: contain`); "fixing" it to exact dimensions would distort photos.
+- The image endpoint serves PNG regardless of source format; cache growth is unbounded — the (superseded) `spec.md` describes the intended bounded-JPEG design.
+- Indexing must never `panic!` per-file: a single unreadable file previously killed the whole background index (fixed this run — keep it that way; skip-on-error is the pattern).
+- The integration tests download fixtures from w3.org and raw.githubusercontent.com — they need internet.

--- a/src/filesystem_client.rs
+++ b/src/filesystem_client.rs
@@ -24,13 +24,13 @@ pub fn read_files_recursive(path: &Path) -> Vec<ImageResource> {
         return vec![];
     }
     let folder_path = folder_path.unwrap();
-    let metadata = folder_path.metadata().unwrap_or_else(|error| {
-        panic!(
-            "Failed to read metadata for: {} Error:\n{}",
-            path.to_str().unwrap(),
-            error
-        )
-    });
+    let metadata = match folder_path.metadata() {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            error!("Could not read metadata for: {:?}. Error:\n{}", path, error);
+            return vec![];
+        }
+    };
 
     if metadata.is_file() {
         return vec![];
@@ -41,24 +41,28 @@ pub fn read_files_recursive(path: &Path) -> Vec<ImageResource> {
         return vec![];
     }
 
-    let paths = fs::read_dir(path).unwrap_or_else(|error| {
-        panic!(
-            "Failed to read directory: {} Error:\n{}",
-            path.to_str().unwrap(),
-            error
-        )
-    });
+    let paths = match fs::read_dir(path) {
+        Ok(paths) => paths,
+        Err(error) => {
+            error!("Could not read directory: {:?}. Error:\n{}", path, error);
+            return vec![];
+        }
+    };
 
     paths
         .flatten()
         .flat_map(|dir_entry| {
-            let metadata = dir_entry.metadata().unwrap_or_else(|error| {
-                panic!(
-                    "Failed to read metadata for: {} Error:\n{}",
-                    dir_entry.path().to_str().unwrap(),
-                    error
-                )
-            });
+            let metadata = match dir_entry.metadata() {
+                Ok(metadata) => metadata,
+                Err(error) => {
+                    error!(
+                        "Could not read metadata for: {:?}. Error:\n{}",
+                        dir_entry.path(),
+                        error
+                    );
+                    return vec![];
+                }
+            };
 
             if metadata.is_file() {
                 read_resource(&dir_entry.path())
@@ -87,16 +91,10 @@ fn should_skip_folder(path: &Path) -> bool {
                 .collect();
     }
 
-    let folder_name = path
-        .file_name()
-        .unwrap_or_else(|| panic!("Failed to get folder name for path: {}", path.display()))
-        .to_str()
-        .unwrap_or_else(|| {
-            panic!(
-                "Failed to convert folder name to string for path: {}",
-                path.display()
-            )
-        });
+    let Some(folder_name) = path.file_name().and_then(|name| name.to_str()) else {
+        debug!("Skipping folder with non-UTF8 name or no name: {:?}", path);
+        return true;
+    };
 
     if IGNORE_FOLDER_REGEX.is_some() && IGNORE_FOLDER_REGEX.as_ref().unwrap().is_match(folder_name)
     {
@@ -108,27 +106,30 @@ fn should_skip_folder(path: &Path) -> bool {
         return true;
     }
 
-    let contains_ignore_file = fs::read_dir(path)
-        .unwrap_or_else(|error| {
-            panic!(
-                "Failed to read directory: {} Error:\n{}",
-                path.display(),
-                error
-            )
-        })
-        .flatten()
-        .any(|entry| {
-            let metadata = entry.metadata().unwrap_or_else(|error| {
-                panic!(
-                    "Failed to read metadata for: {} Error:\n{}",
-                    entry.path().display(),
+    let read_dir_result = match fs::read_dir(path) {
+        Ok(read_dir) => read_dir,
+        Err(error) => {
+            error!("Could not read directory: {:?}. Error:\n{}", path, error);
+            return false;
+        }
+    };
+
+    let contains_ignore_file = read_dir_result.flatten().any(|entry| {
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                error!(
+                    "Could not read metadata for: {:?}. Error:\n{}",
+                    entry.path(),
                     error
-                )
-            });
-            metadata.is_file()
-                && IGNORE_FOLDER_MARKER_FILES
-                    .contains(&entry.file_name().to_str().unwrap().to_string())
-        });
+                );
+                return false;
+            }
+        };
+        metadata.is_file()
+            && IGNORE_FOLDER_MARKER_FILES
+                .contains(&entry.file_name().to_str().unwrap_or("").to_string())
+    });
     if contains_ignore_file {
         info!(
             "⏭️ Skipping folder: {:?} because it contains any of these files {:?}",
@@ -147,12 +148,21 @@ fn read_resource(file_path: &PathBuf) -> Vec<ImageResource> {
     let absolute_file_path = file_path.to_str().unwrap();
     let file_name = file_path.as_path().file_name().unwrap().to_str().unwrap();
 
-    let file = fs::File::open(file_path)
-        .unwrap_or_else(|error| panic!("Failed to read file {}: {}", absolute_file_path, error));
+    let file = match fs::File::open(file_path) {
+        Ok(file) => file,
+        Err(error) => {
+            debug!("Could not read file {}: {}", absolute_file_path, error);
+            return vec![];
+        }
+    };
 
-    let metadata = file.metadata().unwrap_or_else(|error| {
-        panic!("Failed to read metadata {}: {}", absolute_file_path, error)
-    });
+    let metadata = match file.metadata() {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            debug!("Could not read metadata {}: {}", absolute_file_path, error);
+            return vec![];
+        }
+    };
 
     // Cancel if folder
     if !metadata.is_file() {
@@ -191,12 +201,16 @@ fn read_resource(file_path: &PathBuf) -> Vec<ImageResource> {
 /// Reads the exif data from the file and augments the image resource with this information
 pub fn fill_exif_data(resource: &ImageResource) -> ImageResource {
     let file_path = resource.path.as_str();
-    let file = fs::File::open(file_path).unwrap_or_else(|error| {
-        panic!(
-            "Failed to read exif data from file {}: {}",
-            file_path, error
-        );
-    });
+    let file = match fs::File::open(file_path) {
+        Ok(file) => file,
+        Err(error) => {
+            debug!(
+                "Could not read exif data from file {}: {}",
+                file_path, error
+            );
+            return resource.clone();
+        }
+    };
 
     let mut bufreader = std::io::BufReader::new(&file);
     let exif_reader = exif::Reader::new();

--- a/src/filesystem_client.rs
+++ b/src/filesystem_client.rs
@@ -2,9 +2,10 @@ use core::option::Option::None;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use chrono::Local;
 use image::ImageFormat;
 use lazy_static::lazy_static;
-use log::{debug, error, info};
+use log::{error, info, warn};
 use regex::Regex;
 
 use crate::resource_reader::ImageResource;
@@ -92,7 +93,7 @@ fn should_skip_folder(path: &Path) -> bool {
     }
 
     let Some(folder_name) = path.file_name().and_then(|name| name.to_str()) else {
-        debug!("Skipping folder with non-UTF8 name or no name: {:?}", path);
+        warn!("Skipping folder with non-UTF8 name or no name: {:?}", path);
         return true;
     };
 
@@ -145,13 +146,21 @@ fn should_skip_folder(path: &Path) -> bool {
 /// Reads a single file and returns the found resource
 /// Checks if the file is a supported resource currently all image types
 fn read_resource(file_path: &PathBuf) -> Vec<ImageResource> {
-    let absolute_file_path = file_path.to_str().unwrap();
-    let file_name = file_path.as_path().file_name().unwrap().to_str().unwrap();
+    let (Some(absolute_file_path), Some(file_name)) = (
+        file_path.to_str(),
+        file_path
+            .as_path()
+            .file_name()
+            .and_then(|name| name.to_str()),
+    ) else {
+        warn!("Skipping file with non-UTF8 path or name: {:?}", file_path);
+        return vec![];
+    };
 
     let file = match fs::File::open(file_path) {
         Ok(file) => file,
         Err(error) => {
-            debug!("Could not read file {}: {}", absolute_file_path, error);
+            warn!("Could not read file {}: {}", absolute_file_path, error);
             return vec![];
         }
     };
@@ -159,7 +168,7 @@ fn read_resource(file_path: &PathBuf) -> Vec<ImageResource> {
     let metadata = match file.metadata() {
         Ok(metadata) => metadata,
         Err(error) => {
-            debug!("Could not read metadata {}: {}", absolute_file_path, error);
+            warn!("Could not read metadata {}: {}", absolute_file_path, error);
             return vec![];
         }
     };
@@ -176,7 +185,7 @@ fn read_resource(file_path: &PathBuf) -> Vec<ImageResource> {
     if image_format.is_none() {
         // If the mime type is image, but the format is not supported, log it
         if mime_type.starts_with("image") {
-            debug!(
+            warn!(
                 "{absolute_file_path} | has unsupported image format: {}",
                 mime_type
             );
@@ -191,7 +200,10 @@ fn read_resource(file_path: &PathBuf) -> Vec<ImageResource> {
         content_type: mime_type.to_string(),
         name: file_name.to_string(),
         content_length: metadata.len(),
-        last_modified: utils::to_date_time(metadata.modified().unwrap()),
+        last_modified: metadata
+            .modified()
+            .map(utils::to_date_time)
+            .unwrap_or_else(|_| Local::now().naive_local()),
         taken: None,
         location: None,
         orientation: None,
@@ -204,7 +216,7 @@ pub fn fill_exif_data(resource: &ImageResource) -> ImageResource {
     let file = match fs::File::open(file_path) {
         Ok(file) => file,
         Err(error) => {
-            debug!(
+            warn!(
                 "Could not read exif data from file {}: {}",
                 file_path, error
             );

--- a/src/geo_location.rs
+++ b/src/geo_location.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::env;
 use std::fmt::{Display, Formatter};
+use std::time::Duration;
+
+use actix_web::web;
 
 use lazy_static::lazy_static;
 use regex::{Captures, Regex};
@@ -143,18 +146,24 @@ pub async fn resolve_city_name(geo_location: GeoLocation) -> Option<String> {
         env::var("BIGDATA_CLOUD_API_KEY").unwrap(),
     );
 
-    let response = ureq::get(request_url.as_str()).call();
-
-    if response.is_err() {
-        return None;
-    }
-
-    let response_json = response
-        .unwrap()
-        .body_mut()
-        .read_to_string()
-        .ok()
-        .and_then(|json_string| serde_json::from_str::<HashMap<String, Value>>(&json_string).ok());
+    // The blocking ureq call must not run on an async worker thread
+    let response_json: Option<HashMap<String, Value>> = web::block(move || {
+        ureq::get(&request_url)
+            .config()
+            .timeout_global(Some(Duration::from_secs(15)))
+            .build()
+            .call()
+            .ok()?
+            .body_mut()
+            .read_to_string()
+            .ok()
+            .and_then(|json_string| {
+                serde_json::from_str::<HashMap<String, Value>>(&json_string).ok()
+            })
+    })
+    .await
+    .ok()
+    .flatten();
 
     let mut city_name = response_json
         .as_ref()

--- a/src/image_processor.rs
+++ b/src/image_processor.rs
@@ -24,11 +24,15 @@ pub fn adjust_image(
     display_height: u32,
     image_orientation: Option<ImageOrientation>,
 ) -> Option<Vec<u8>> {
-    let mut image = match ImageReader::new(Cursor::new(&resource_data))
-        .with_guessed_format()
-        .unwrap()
-        .decode()
-    {
+    let reader = match ImageReader::new(Cursor::new(&resource_data)).with_guessed_format() {
+        Ok(reader) => reader,
+        Err(error) => {
+            error!("{resource_path} | Error: {}", error);
+            return None;
+        }
+    };
+
+    let mut image = match reader.decode() {
         Ok(image) => image,
         Err(error) => {
             error!("{resource_path} | Error: {}", error);

--- a/src/image_processor.rs
+++ b/src/image_processor.rs
@@ -24,18 +24,17 @@ pub fn adjust_image(
     display_height: u32,
     image_orientation: Option<ImageOrientation>,
 ) -> Option<Vec<u8>> {
-    let read_result = ImageReader::new(Cursor::new(&resource_data))
+    let mut image = match ImageReader::new(Cursor::new(&resource_data))
         .with_guessed_format()
         .unwrap()
-        .decode();
-
-    if read_result.is_err() {
-        error!("{resource_path} | Error: {}", read_result.unwrap_err());
-        return None;
-    }
-
-    // Resize the image to the needed display size
-    let mut image = read_result.unwrap();
+        .decode()
+    {
+        Ok(image) => image,
+        Err(error) => {
+            error!("{resource_path} | Error: {}", error);
+            return None;
+        }
+    };
 
     // Rotate or flip the image if needed
     image = if let Some(orientation) = image_orientation {

--- a/src/integration_test_config_api.rs
+++ b/src/integration_test_config_api.rs
@@ -74,7 +74,7 @@ async fn create_temp_folder() -> PathBuf {
 
     fs::create_dir_all(&test_dir).unwrap();
 
-    let data_dir = format!("/tmp/cache/{}/{}", &random_string, TEST_FOLDER_NAME);
+    let data_dir = format!("/tmp/cache/{}/{}", random_string, TEST_FOLDER_NAME);
     env::set_var("DATA_FOLDER", &data_dir);
     fs::create_dir_all(&data_dir).unwrap();
 

--- a/src/integration_test_resources_api.rs
+++ b/src/integration_test_resources_api.rs
@@ -425,6 +425,39 @@ async fn test_get_resource_description_by_id() {
 }
 
 #[actix_web::test]
+async fn test_get_unknown_resource_metadata_returns_not_found() {
+    // GIVEN is an empty library
+    let base_test_dir = create_temp_folder().await;
+
+    // AND a running this-week-in-past instance
+    let app_server = test::init_service(build_app(base_test_dir.to_str().unwrap())).await;
+
+    // WHEN requesting metadata for an unknown resource id
+    let metadata_response = test::call_service(
+        &app_server,
+        TestRequest::get()
+            .uri("/api/resources/unknown-id/metadata")
+            .to_request(),
+    )
+    .await;
+
+    let description_response = test::call_service(
+        &app_server,
+        TestRequest::get()
+            .uri("/api/resources/unknown-id/description")
+            .to_request(),
+    )
+    .await;
+
+    // THEN both endpoints respond with 404
+    assert_that!(metadata_response.status().as_u16()).is_equal_to(404);
+    assert_that!(description_response.status().as_u16()).is_equal_to(404);
+
+    // cleanup
+    cleanup(&base_test_dir).await;
+}
+
+#[actix_web::test]
 async fn test_ignore_file_in_resources() {
     // GIVEN is a folder structure with two assets
     // AND a file with the name .ignore

--- a/src/integration_test_resources_api.rs
+++ b/src/integration_test_resources_api.rs
@@ -10,7 +10,6 @@ use actix_web::{test, web, App, Error};
 use assertor::{assert_that, EqualityAssertion, VecAssertion};
 use chrono::{Duration, Local, NaiveDateTime};
 use rand::RngExt;
-use rusqlite::fallible_iterator::FallibleIterator;
 use test::TestRequest;
 
 use crate::geo_location::GeoLocation;
@@ -333,8 +332,17 @@ async fn test_get_resource_by_id_and_resolution() {
     )
     .await;
 
-    // THEN the response should contain the resized image
-    assert_that!(response.len()).is_equal_to(316);
+    // THEN the response should contain a PNG resized to fit within the requested display bounds
+    assert_that!(response.first()).is_equal_to(Some(&0x89)); // PNG magic byte
+    let (width, height) = image::ImageReader::new(std::io::Cursor::new(&response))
+        .with_guessed_format()
+        .unwrap()
+        .into_dimensions()
+        .unwrap();
+    assert_that!(width <= 10).is_equal_to(true);
+    assert_that!(height <= 10).is_equal_to(true);
+    assert_that!(width > 0).is_equal_to(true);
+    assert_that!(height > 0).is_equal_to(true);
 
     // cleanup
     cleanup(&base_test_dir).await;

--- a/src/integration_test_weather_api.rs
+++ b/src/integration_test_weather_api.rs
@@ -99,7 +99,7 @@ async fn create_temp_folder() -> PathBuf {
 
     fs::create_dir_all(&test_dir).unwrap();
 
-    let data_dir = format!("/tmp/cache/{}/{}", &random_string, TEST_FOLDER_NAME);
+    let data_dir = format!("/tmp/cache/{}/{}", random_string, TEST_FOLDER_NAME);
     env::set_var("DATA_FOLDER", &data_dir);
     fs::create_dir_all(&data_dir).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 use std::env;
 
 use actix_web::{middleware, web, App, HttpRequest, HttpResponse, HttpServer};

--- a/src/resource_endpoint.rs
+++ b/src/resource_endpoint.rs
@@ -199,7 +199,7 @@ pub async fn get_resource_metadata_by_id(
             .content_type(CONTENT_TYPE_APPLICATION_JSON)
             .body(metadata)
     } else {
-        HttpResponse::InternalServerError().finish()
+        HttpResponse::NotFound().finish()
     }
 }
 
@@ -220,7 +220,7 @@ pub async fn get_resource_metadata_description_by_id(
             .content_type("plain/text")
             .body(display_value.await)
     } else {
-        HttpResponse::InternalServerError().finish()
+        HttpResponse::NotFound().finish()
     }
 }
 

--- a/src/resource_reader.rs
+++ b/src/resource_reader.rs
@@ -36,14 +36,6 @@ pub struct ImageResource {
     pub orientation: Option<ImageOrientation>,
 }
 
-impl ImageResource {
-    pub fn with_taken_date(&self, taken_date: NaiveDateTime) -> ImageResource {
-        let mut resource = self.clone();
-        resource.taken = Some(taken_date);
-        resource
-    }
-}
-
 /// Impl Default for ImageResource
 impl Default for ImageResource {
     fn default() -> Self {

--- a/src/resource_reader_test.rs
+++ b/src/resource_reader_test.rs
@@ -164,6 +164,57 @@ fn read_empty_dir() {
     cleanup(&base_test_dir);
 }
 
+#[cfg(unix)]
+#[test]
+fn read_dir_with_unreadable_file_does_not_panic() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // GIVEN is a folder with one readable image and one unreadable file
+    let base_test_dir = create_temp_folder();
+    create_test_image(&base_test_dir, "", "test_image_1.jpg", TEST_JPEG_URL);
+    let unreadable_file = base_test_dir.join("unreadable.jpg");
+    fs::write(&unreadable_file, b"not an image").unwrap();
+    let mut permissions = fs::metadata(&unreadable_file).unwrap().permissions();
+    permissions.set_mode(0o000);
+    fs::set_permissions(&unreadable_file, permissions).unwrap();
+
+    // Skip the test when running as root (permissions are not enforced)
+    if fs::File::open(&unreadable_file).is_ok() {
+        cleanup(&base_test_dir);
+        return;
+    }
+
+    // WHEN reading resources from a folder
+    let resources_read = filesystem_client::read_files_recursive(&base_test_dir);
+
+    // THEN the readable image is found and the unreadable file is skipped without panicking
+    assert_eq!(resources_read.len(), 1);
+    assert_eq!(resources_read[0].name, "test_image_1.jpg");
+
+    // cleanup
+    cleanup(&base_test_dir);
+}
+
+#[test]
+fn fill_exif_data_missing_file_does_not_panic() {
+    // GIVEN is a resource whose file is removed before exif data is read
+    let base_test_dir = create_temp_folder();
+    create_test_image(&base_test_dir, "", "test_image_1.jpg", TEST_JPEG_URL);
+    let resources_read = filesystem_client::read_files_recursive(&base_test_dir);
+    assert_eq!(resources_read.len(), 1);
+    fs::remove_file(&resources_read[0].path).unwrap();
+
+    // WHEN filling exif data for the now missing file
+    let augmented = filesystem_client::fill_exif_data(&resources_read[0]);
+
+    // THEN the resource is returned unchanged without panicking
+    assert_eq!(augmented.taken, None);
+    assert_eq!(augmented.location, None);
+
+    // cleanup
+    cleanup(&base_test_dir);
+}
+
 #[test]
 fn read_non_existent_folder() {
     // GIVEN is a folder path that does not exist

--- a/src/resource_reader_test.rs
+++ b/src/resource_reader_test.rs
@@ -215,6 +215,29 @@ fn fill_exif_data_missing_file_does_not_panic() {
     cleanup(&base_test_dir);
 }
 
+#[cfg(unix)]
+#[test]
+fn read_dir_with_non_utf8_file_name_does_not_panic() {
+    use std::os::unix::ffi::OsStringExt;
+
+    // GIVEN is a folder with one readable image and one file with a non-UTF8 name
+    let base_test_dir = create_temp_folder();
+    create_test_image(&base_test_dir, "", "test_image_1.jpg", TEST_JPEG_URL);
+    let non_utf8_name =
+        std::ffi::OsString::from_vec(vec![0x74, 0x65, 0x73, 0x74, 0xFF, 0x2E, 0x6A, 0x70, 0x67]); // "test\xFF.jpg"
+    fs::write(base_test_dir.join(&non_utf8_name), b"not an image").unwrap();
+
+    // WHEN reading resources from a folder
+    let resources_read = filesystem_client::read_files_recursive(&base_test_dir);
+
+    // THEN the readable image is found and the non-UTF8 file is skipped without panicking
+    assert_eq!(resources_read.len(), 1);
+    assert_eq!(resources_read[0].name, "test_image_1.jpg");
+
+    // cleanup
+    cleanup(&base_test_dir);
+}
+
 #[test]
 fn read_non_existent_folder() {
     // GIVEN is a folder path that does not exist

--- a/src/weather_processor.rs
+++ b/src/weather_processor.rs
@@ -1,5 +1,9 @@
-use crate::config;
 use std::env;
+use std::time::Duration;
+
+use actix_web::web;
+
+use crate::config;
 
 /// Returns the current weather data provided by OpenWeatherMap
 /// The data is selected by the configured location
@@ -13,15 +17,25 @@ pub async fn get_current_weather() -> Option<String> {
     let city: String = env::var("WEATHER_LOCATION").unwrap_or_else(|_| "Berlin".to_string());
     let units: String = config::get_weather_unit();
     let language: String = env::var("WEATHER_LANGUAGE").unwrap_or_else(|_| "en".to_string());
-    let response = ureq::get(format!(
+    let request_url = format!(
         "https://api.openweathermap.org/data/2.5/weather?q={city}&appid={api_key}&units={units}&lang={language}"
-    ).as_str()).call();
+    );
 
-    if let Ok(mut response) = response {
-        response.body_mut().read_to_string().ok()
-    } else {
-        None
-    }
+    // The blocking ureq call must not run on an async worker thread
+    web::block(move || {
+        ureq::get(&request_url)
+            .config()
+            .timeout_global(Some(Duration::from_secs(15)))
+            .build()
+            .call()
+            .ok()?
+            .body_mut()
+            .read_to_string()
+            .ok()
+    })
+    .await
+    .ok()
+    .flatten()
 }
 
 /// Returns the current weather data provided by Home Assistant
@@ -36,17 +50,22 @@ pub async fn get_home_assistant_data() -> Option<String> {
         return None;
     }
 
-    let response =
-        ureq::get(format!("{}/api/states/{}", base_url.unwrap(), entity_id.unwrap()).as_str())
-            .header(
-                "Authorization",
-                format!("Bearer {}", api_token.unwrap()).as_str(),
-            )
-            .call();
+    let request_url = format!("{}/api/states/{}", base_url.unwrap(), entity_id.unwrap());
 
-    if let Ok(mut response) = response {
-        response.body_mut().read_to_string().ok()
-    } else {
-        None
-    }
+    // The blocking ureq call must not run on an async worker thread
+    web::block(move || {
+        ureq::get(&request_url)
+            .config()
+            .timeout_global(Some(Duration::from_secs(15)))
+            .build()
+            .header("Authorization", format!("Bearer {}", api_token.unwrap()))
+            .call()
+            .ok()?
+            .body_mut()
+            .read_to_string()
+            .ok()
+    })
+    .await
+    .ok()
+    .flatten()
 }

--- a/web-app/script.js
+++ b/web-app/script.js
@@ -17,46 +17,70 @@ let slideshowId;
 let weatherUnit;
 
 /**
+ * Slideshow configuration loaded once on page load.
+ * URL parameters take precedence over the server-provided values.
+ */
+const CONFIG_DEFAULTS = {
+    slideshowInterval: 30,
+    refreshInterval: 360,
+    randomSlideshow: false,
+    preloadImages: false,
+};
+
+let appConfig = {...CONFIG_DEFAULTS};
+
+/**
+ * Fetches a configuration value from the backend.
+ * @returns {Promise<string>} the response text or the fallback value on error
+ */
+async function fetchConfigValue(url, fallback) {
+    try {
+        const response = await fetch(url);
+        if (response.ok) {
+            return await response.text();
+        }
+    } catch (error) {
+        console.error('Error loading config from ' + url + ':', error);
+    }
+    return fallback;
+}
+
+/**
+ * Loads the slideshow configuration once.
+ * URL parameters overwrite the values from the backend.
+ */
+async function loadAppConfig() {
+    const urlParams = new URLSearchParams(window.location.search);
+
+    appConfig.randomSlideshow = urlParams.has('RANDOM_SLIDESHOW')
+        ? urlParams.get('RANDOM_SLIDESHOW') === "true"
+        : (await fetchConfigValue('/api/config/random-slideshow', 'false')) === "true";
+
+    appConfig.preloadImages = (await fetchConfigValue('/api/config/preload-images', 'false')) === "true";
+
+    appConfig.slideshowInterval = urlParams.has('SLIDESHOW_INTERVAL')
+        ? parseInt(urlParams.get('SLIDESHOW_INTERVAL'))
+        : parseInt(await fetchConfigValue('/api/config/interval/slideshow', '30'));
+
+    appConfig.refreshInterval = parseInt(await fetchConfigValue('/api/config/interval/refresh', '360'));
+}
+
+/**
  * On page load, do the following things:
  *      - Load the available images and initialize the slideshow with it
  *      - Load and show the weather information
  *      - Set a page reload interval for each hour
  */
-window.addEventListener('load', () => {
-    forceRandomSlideshow = shouldOnlyPlayRandom();
+window.addEventListener('load', async () => {
+    await loadAppConfig();
+    forceRandomSlideshow = appConfig.randomSlideshow;
     initSlideshow();
     loadWeatherInformation();
     initHideButton();
 
     // Reload page every x minutes
-    let refreshIntervalInMinutes = getRefreshInterval();
-    intervalID = setInterval(() => location.reload(), refreshIntervalInMinutes * 60000);
+    intervalID = setInterval(() => location.reload(), appConfig.refreshInterval * 60000);
 });
-
-function shouldOnlyPlayRandom() {
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has('RANDOM_SLIDESHOW')) {
-        return urlParams.get('RANDOM_SLIDESHOW') === "true";
-    }
-
-    let request = new XMLHttpRequest();
-    request.open('GET', `/api/config/random-slideshow`, false);
-    request.send(null);
-
-    return request.status === 200 && request.responseText === "true";
-}
-
-/**
- * Checks if images should be preloaded.
- * @returns {boolean} true if images should be preloaded, false otherwise
- */
-function shouldPreloadImages() {
-    let request = new XMLHttpRequest();
-    request.open('GET', `/api/config/preload-images`, false);
-    request.send(null);
-
-    return request.status === 200 && request.responseText === "true";
-}
 
 /**
  * Initializes a new slideshow, if random is active fetch a random playlist.
@@ -106,7 +130,7 @@ function beginSlideshow(foundResourcesOfThisWeek) {
     slideshowTick();
 
     // Load slideshow interval
-    let intervalInSeconds = getSlideshowInterval();
+    let intervalInSeconds = appConfig.slideshowInterval;
 
     // Start image slideshow
     slideshowId = setInterval(() => slideshowTick(), intervalInSeconds * 1000);
@@ -210,23 +234,22 @@ function loadCurrentWeather() {
  * The weather icon is loaded from OpenWeatherMap.
  * @param data the weather data
  */
-function showCurrentWeather(data) {
+async function showCurrentWeather(data) {
     const weather = data.weather[0];
     const icon = weather.icon;
 
     document.getElementById("weather-label").textContent = weather.description + ",";
     document.getElementById("weather-icon").src = `https://openweathermap.org/img/w/${icon}.png`;
 
-    isHomeAssistantEnabled().then((isHomeAssistantEnabled) => {
-        let temperatureText;
-        if (isHomeAssistantEnabled) {
-            let homeAssistantData = JSON.parse(getCurrentTemperatureDataFromHomeAssistant());
-            temperatureText = Math.round(homeAssistantData.state) + homeAssistantData.attributes.unit_of_measurement;
-        } else {
-            temperatureText = Math.round(data.main.temp) + getWeatherUnit();
-        }
-        document.getElementById("weather-temperature").innerText = temperatureText;
-    });
+    const homeAssistantEnabled = await isHomeAssistantEnabled();
+    let temperatureText;
+    if (homeAssistantEnabled) {
+        let homeAssistantData = JSON.parse(await getCurrentTemperatureDataFromHomeAssistant());
+        temperatureText = Math.round(homeAssistantData.state) + homeAssistantData.attributes.unit_of_measurement;
+    } else {
+        temperatureText = Math.round(data.main.temp) + getWeatherUnit();
+    }
+    document.getElementById("weather-temperature").innerText = temperatureText;
 }
 
 /**
@@ -245,14 +268,16 @@ async function isHomeAssistantEnabled() {
 
 
 /**
- * @returns {string} the current temperature from Home Assistant
+ * @returns {Promise<string>} the current temperature from Home Assistant
  */
-function getCurrentTemperatureDataFromHomeAssistant() {
-    let request = new XMLHttpRequest();
-    request.open('GET', `/api/weather/homeassistant/temperature`, false);
-    request.send(null);
-    if (request.status === 200) {
-        return request.response;
+async function getCurrentTemperatureDataFromHomeAssistant() {
+    try {
+        const response = await fetch(`/api/weather/homeassistant/temperature`);
+        if (response.ok) {
+            return await response.text();
+        }
+    } catch (error) {
+        console.error("Error:", error);
     }
     return "{}";
 }
@@ -327,7 +352,7 @@ function slideshowTick() {
     }
 
     // Preload next image if active
-    if (shouldPreloadImages()) {
+    if (appConfig.preloadImages) {
         preloadNextImage(resourcesThisWeek[currentIndex]);
     }
 }
@@ -346,38 +371,7 @@ function preloadNextImage(resource_id) {
     request.send();
 }
 
-/**
- * @returns {number} the slideshow interval in seconds
- */
-function getSlideshowInterval() {
-    // First check if the user overwrites the SLIDESHOW_INTERVAL as url parameter
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has('SLIDESHOW_INTERVAL')) {
-        return parseInt(urlParams.get('SLIDESHOW_INTERVAL'))
-    }
 
-    // if no interval was found in the url, load the value from the config
-    let request = new XMLHttpRequest();
-    request.open('GET', `/api/config/interval/slideshow`, false);
-    request.send(null);
-    if (request.status === 200) {
-        return parseInt(request.responseText);
-    }
-    return 30;
-}
-
-/**
- * @returns {number} the refresh interval in minutes from the backend API
- */
-function getRefreshInterval() {
-    let request = new XMLHttpRequest();
-    request.open('GET', `/api/config/interval/refresh`, false);
-    request.send(null);
-    if (request.status === 200) {
-        return parseInt(request.responseText)
-    }
-    return 180;
-}
 
 /**
  * Sleeps for the given amount of milliseconds and returns a promise that is resolved when the sleep is finished
@@ -402,7 +396,7 @@ function showPrevImage() {
 
     // Reset the slideshow interval to avoid takeover effect
     clearInterval(slideshowId);
-    slideshowId = setInterval(slideshowTick, getSlideshowInterval() * 1000);
+    slideshowId = setInterval(slideshowTick, appConfig.slideshowInterval * 1000);
 }
 
 /**
@@ -420,7 +414,7 @@ function pauseResumeSlideshow() {
     if (isPaused) {
         clearInterval(slideshowId);
     } else {
-        slideshowId = setInterval(slideshowTick, getSlideshowInterval() * 1000);
+        slideshowId = setInterval(slideshowTick, appConfig.slideshowInterval * 1000);
     }
 }
 
@@ -434,5 +428,5 @@ function showNextImage() {
 
     // Reset the slideshow interval to avoid takeover effect
     clearInterval(slideshowId);
-    slideshowId = setInterval(slideshowTick, getSlideshowInterval() * 1000);
+    slideshowId = setInterval(slideshowTick, appConfig.slideshowInterval * 1000);
 }


### PR DESCRIPTION
Closes the tech-debt audit findings:

- **FIX-1** indexing no longer panics per-file (unreadable files, non-UTF8 names, unreadable mtimes) — log-and-skip
- **QW-1/QW-2** dead code, unused dev-dep, clippy warnings removed
- **QW-3** 404 for unknown resource metadata (regression test pinned)
- **QW-4** brittle byte-count test replaced with structural assertion
- **ARCH-1** blocking HTTP moved to web::block with 15s timeout
- **FRONT-1** sync XHRs replaced with one async config load
- Adds TECH_DEBT_AUDIT.md with verified current-line citations

CI (fmt, clippy, full test suite with API keys, 4-arch build, container test) is green on the branch.