### PR TITLE
fix: remove image dimension and pixel limits

### DIFF
--- a/src/image_processor.rs
+++ b/src/image_processor.rs
@@ -5,9 +5,6 @@ use image::imageops::FilterType;
 use image::ImageReader;
 use serde::{Deserialize, Serialize};
 
-const MAX_DIM: u32 = 10_000;
-const MAX_PIXELS: u64 = 50_000_000;
-
 /// Represents the orientation of an image in two dimensions
 /// rotation:               0, 90, 180 or 270
 /// mirror_vertically:      true, if the image is mirrored vertically
@@ -27,16 +24,6 @@ pub fn adjust_image(
     display_height: u32,
     image_orientation: Option<ImageOrientation>,
 ) -> Option<Vec<u8>> {
-    // Guard before full decode: peek dimensions without allocating pixels
-    if let Ok(reader) = ImageReader::new(Cursor::new(&resource_data)).with_guessed_format() {
-        if let Ok((w, h)) = reader.into_dimensions() {
-            if w > MAX_DIM || h > MAX_DIM || (w as u64 * h as u64) > MAX_PIXELS {
-                log::warn!("{resource_path} | Rejected: {w}x{h} exceeds limit");
-                return None;
-            }
-        }
-    }
-
     let reader = match ImageReader::new(Cursor::new(&resource_data)).with_guessed_format() {
         Ok(reader) => reader,
         Err(error) => {
@@ -52,19 +39,6 @@ pub fn adjust_image(
             return None;
         }
     };
-    // Post-decode guard: peek may have failed or been bypassed, enforce limits after allocation
-    if image.width() > MAX_DIM
-        || image.height() > MAX_DIM
-        || (image.width() as u64 * image.height() as u64) > MAX_PIXELS
-    {
-        log::warn!(
-            "{resource_path} | Rejected post-decode: {}x{} exceeds limit",
-            image.width(),
-            image.height()
-        );
-        return None;
-    }
-
     // Rotate or flip the image if needed
     image = if let Some(orientation) = image_orientation {
         let rotated = match orientation.rotation {
@@ -119,19 +93,20 @@ mod tests {
     }
 
     #[test]
-    fn adjust_image_rejects_huge_image() {
-        // GIVEN a huge 11_000x11_000 image exceeding 10_000 limit
-        let huge = image::RgbImage::new(11_000, 11_000);
+    fn adjust_image_accepts_panorama_without_limits() {
+        // GIVEN a wide 11_000x100 panorama exceeding the former 10_000 dimension cap
+        let pano = image::RgbImage::new(11_000, 100);
         let mut buf = Vec::new();
-        image::DynamicImage::ImageRgb8(huge)
+        image::DynamicImage::ImageRgb8(pano)
             .write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png)
             .unwrap();
 
-        // WHEN attempting to adjust the huge image
-        let out = adjust_image("huge.png".into(), buf, 100, 100, None);
+        // WHEN adjusting the panorama
+        let out = adjust_image("pano.png".into(), buf, 100, 100, None);
 
-        // THEN the image is rejected (None) to prevent OOM
-        assert!(out.is_none(), "should reject >10000");
+        // THEN the image is processed (no dimension limits)
+        let out = out.expect("panorama must not be rejected");
+        assert_eq!(&out[0..2], &[0xFF, 0xD8], "must be JPEG magic");
     }
 
     #[test]


### PR DESCRIPTION
Panoramas wider than 10000px (e.g. 10672x3776, ~40MP) were rejected with 'exceeds limit'. Removes the pre/post-decode dimension and pixel guards entirely; decode proceeds regardless of size. Replaces the rejection test with a panorama acceptance test.