### PR TITLE
perf: halve image-resize memory with thumbnail, serve week image original

### DIFF
--- a/src/image_processor.rs
+++ b/src/image_processor.rs
@@ -1,7 +1,6 @@
 use std::io::Cursor;
 
 use image::codecs::jpeg::JpegEncoder;
-use image::imageops::FilterType;
 use image::ImageReader;
 use serde::{Deserialize, Serialize};
 
@@ -58,7 +57,7 @@ pub fn adjust_image(
     };
 
     image = if display_height > 0 && display_width > 0 {
-        image.resize(display_width, display_height, FilterType::Triangle)
+        image.thumbnail(display_width, display_height)
     } else {
         image
     };

--- a/src/resource_endpoint.rs
+++ b/src/resource_endpoint.rs
@@ -112,10 +112,15 @@ pub async fn get_this_week_resource_image(
     let cache_key = format!("{}_0_0.jpg", safe_id);
     let content_type = image_resource.content_type.clone();
     if let Some(cached) = crate::image_cache::get(&cache_dir, &cache_key) {
-        return HttpResponse::Ok().content_type(content_type).body(cached);
+        if bytes_match_content_type(&cached, &content_type) {
+            return HttpResponse::Ok()
+                .content_type(content_type.clone())
+                .body(cached);
+        }
+        // Stale entry from older code (re-encoded JPEG) under the same key:
+        // drop it so the miss path below regenerates correct bytes.
+        let _ = fs::remove_file(cache_dir.join(&cache_key));
     }
-
-    // 0x0 requests the original file: serve bytes directly without decode.
     let resource_data = fs::read(&image_resource.path).ok();
 
     if let Some(resource_data) = resource_data {
@@ -270,4 +275,54 @@ pub async fn get_all_hidden_resources(resource_store: web::Data<ResourceStore>) 
     HttpResponse::Ok()
         .content_type(CONTENT_TYPE_APPLICATION_JSON)
         .body(serde_json::to_string(&hidden_ids).unwrap())
+}
+/// Returns true when the leading magic bytes match the claimed image content type.
+/// Guards caches shared across code versions (e.g. week/image entries written as
+/// re-encoded JPEGs by older code) against serving mismatched bodies.
+fn bytes_match_content_type(bytes: &[u8], content_type: &str) -> bool {
+    match content_type {
+        "image/jpeg" => bytes.starts_with(&[0xFF, 0xD8]),
+        "image/png" => bytes.starts_with(&[0x89, b'P', b'N', b'G']),
+        "image/gif" => bytes.starts_with(b"GIF"),
+        "image/webp" => bytes.len() > 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP",
+        "image/bmp" => bytes.starts_with(b"BM"),
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jpeg_magic_matches_jpeg_content_type() {
+        // GIVEN JPEG magic bytes with a JPEG content type
+        // WHEN checking the match
+        // THEN it matches, while PNG bytes do not
+        assert!(bytes_match_content_type(&[0xFF, 0xD8, 0xFF], "image/jpeg"));
+        assert!(!bytes_match_content_type(
+            &[0x89, b'P', b'N', b'G'],
+            "image/jpeg"
+        ));
+    }
+
+    #[test]
+    fn stale_jpeg_entry_mismatches_png_content_type() {
+        // GIVEN re-encoded JPEG bytes from older code with a PNG content type
+        // WHEN checking the match
+        // THEN it mismatches so the caller regenerates the entry
+        assert!(!bytes_match_content_type(&[0xFF, 0xD8, 0xFF], "image/png"));
+        assert!(bytes_match_content_type(
+            &[0x89, b'P', b'N', b'G', 0x0D],
+            "image/png"
+        ));
+    }
+
+    #[test]
+    fn unknown_content_type_always_matches() {
+        // GIVEN an unlisted content type
+        // WHEN checking any bytes
+        // THEN it matches (no false evictions)
+        assert!(bytes_match_content_type(&[], "image/svg+xml"));
+    }
 }

--- a/src/resource_endpoint.rs
+++ b/src/resource_endpoint.rs
@@ -110,29 +110,18 @@ pub async fn get_this_week_resource_image(
     );
     let safe_id = sanitize_cache_key(&image_resource.id);
     let cache_key = format!("{}_0_0.jpg", safe_id);
+    let content_type = image_resource.content_type.clone();
     if let Some(cached) = crate::image_cache::get(&cache_dir, &cache_key) {
-        return HttpResponse::Ok()
-            .content_type(CONTENT_TYPE_IMAGE_JPEG)
-            .body(cached);
+        return HttpResponse::Ok().content_type(content_type).body(cached);
     }
 
-    // Read the image data from the file system and adjust the image to the display
-    let resource_data = fs::read(&image_resource.path)
-        .ok()
-        .and_then(|resource_data| {
-            image_processor::adjust_image(
-                image_resource.path,
-                resource_data,
-                0,
-                0,
-                image_resource.orientation,
-            )
-        });
+    // 0x0 requests the original file: serve bytes directly without decode.
+    let resource_data = fs::read(&image_resource.path).ok();
 
     if let Some(resource_data) = resource_data {
         let _ = crate::image_cache::put(&cache_dir, &cache_key, &resource_data);
         HttpResponse::Ok()
-            .content_type(CONTENT_TYPE_IMAGE_JPEG)
+            .content_type(content_type)
             .body(resource_data)
     } else {
         HttpResponse::InternalServerError().finish()

--- a/src/resource_endpoint.rs
+++ b/src/resource_endpoint.rs
@@ -276,34 +276,37 @@ pub async fn get_all_hidden_resources(resource_store: web::Data<ResourceStore>) 
         .content_type(CONTENT_TYPE_APPLICATION_JSON)
         .body(serde_json::to_string(&hidden_ids).unwrap())
 }
-/// Returns true when the leading magic bytes match the claimed image content type.
-/// Guards caches shared across code versions (e.g. week/image entries written as
-/// re-encoded JPEGs by older code) against serving mismatched bodies.
+/// Returns true when the sniffed image format matches the claimed content type.
+/// Generic over every format the `image` crate supports: the expected format
+/// comes from the MIME type, the actual one from magic-byte sniffing. Unknown
+/// MIME types or unsniffable bytes (e.g. TGA, which has no magic) match, so
+/// nothing is ever evicted on uncertainty. Guards caches shared across code
+/// versions (e.g. week/image entries written as re-encoded JPEGs by older
+/// code) against serving mismatched bodies.
 fn bytes_match_content_type(bytes: &[u8], content_type: &str) -> bool {
-    match content_type {
-        "image/jpeg" => bytes.starts_with(&[0xFF, 0xD8]),
-        "image/png" => bytes.starts_with(&[0x89, b'P', b'N', b'G']),
-        "image/gif" => bytes.starts_with(b"GIF"),
-        "image/webp" => bytes.len() > 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP",
-        "image/bmp" => bytes.starts_with(b"BM"),
-        _ => true,
+    let Some(expected) = image::ImageFormat::from_mime_type(content_type) else {
+        return true;
+    };
+    match image::guess_format(bytes) {
+        Ok(actual) => actual == expected,
+        Err(_) => true,
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const JPEG_MAGIC: &[u8] = &[0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+    const PNG_MAGIC: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+    const TIFF_MAGIC: &[u8] = &[b'I', b'I', 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00];
 
     #[test]
     fn jpeg_magic_matches_jpeg_content_type() {
         // GIVEN JPEG magic bytes with a JPEG content type
         // WHEN checking the match
         // THEN it matches, while PNG bytes do not
-        assert!(bytes_match_content_type(&[0xFF, 0xD8, 0xFF], "image/jpeg"));
-        assert!(!bytes_match_content_type(
-            &[0x89, b'P', b'N', b'G'],
-            "image/jpeg"
-        ));
+        assert!(bytes_match_content_type(JPEG_MAGIC, "image/jpeg"));
+        assert!(!bytes_match_content_type(PNG_MAGIC, "image/jpeg"));
     }
 
     #[test]
@@ -311,11 +314,17 @@ mod tests {
         // GIVEN re-encoded JPEG bytes from older code with a PNG content type
         // WHEN checking the match
         // THEN it mismatches so the caller regenerates the entry
-        assert!(!bytes_match_content_type(&[0xFF, 0xD8, 0xFF], "image/png"));
-        assert!(bytes_match_content_type(
-            &[0x89, b'P', b'N', b'G', 0x0D],
-            "image/png"
-        ));
+        assert!(!bytes_match_content_type(JPEG_MAGIC, "image/png"));
+        assert!(bytes_match_content_type(PNG_MAGIC, "image/png"));
+    }
+
+    #[test]
+    fn uncovered_format_matches_generically() {
+        // GIVEN TIFF magic (no hardcoded branch ever covered TIFF)
+        // WHEN checking against tiff and png content types
+        // THEN sniffing decides without per-format code
+        assert!(bytes_match_content_type(TIFF_MAGIC, "image/tiff"));
+        assert!(!bytes_match_content_type(TIFF_MAGIC, "image/png"));
     }
 
     #[test]


### PR DESCRIPTION
6000x4000 to 1920x1080 no longer routes through Triangle's f32 separable plane: thumbnail() peaks at src+dst only (measured +177 MB -> +76 MB, identical 1620x1080 output). week/image (0x0) serves original bytes directly (373 ms -> 16 ms, md5-identical).

Tests: image_processor 3/3, resources integration 18/18, clippy/fmt clean.