### PR TITLE
perf: retain warm image cache across re-indexes

### DIFF
--- a/src/image_cache.rs
+++ b/src/image_cache.rs
@@ -75,9 +75,10 @@ pub fn put(cache_dir: &Path, key: &str, data: &[u8]) -> io::Result<()> {
     Ok(())
 }
 /// Removes cached entries whose resource id is not in `keep_ids`.
-/// Cache keys are `{id}_{width}_{height}.jpg`; the id is the part before
-/// the first '_'. Files without '_' or with invalid keys are kept (the LRU
-/// bounds in `put` still apply to them).
+/// Cache keys are `{id}_{width}_{height}.jpg`; the id is everything before
+/// the trailing `_{width}_{height}.jpg` (parsed from the right, since
+/// sanitized ids may themselves contain '_'). Files of unknown shape or with
+/// invalid keys are kept (the LRU bounds in `put` still apply to them).
 /// Thread-safe via the global mutex; returns `Ok(())` if the directory does not exist.
 pub fn retain(cache_dir: &Path, keep_ids: &HashSet<String>) -> io::Result<()> {
     let _guard = CACHE_MUTEX.lock();
@@ -89,7 +90,7 @@ pub fn retain(cache_dir: &Path, keep_ids: &HashSet<String>) -> io::Result<()> {
         if name.starts_with(".tmp-") || !is_valid_key(&name) {
             continue;
         }
-        let Some((id, _)) = name.split_once('_') else {
+        let Some(id) = cache_key_id(&name) else {
             continue;
         };
         if !keep_ids.contains(id) {
@@ -97,6 +98,21 @@ pub fn retain(cache_dir: &Path, keep_ids: &HashSet<String>) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Extracts the resource id from a `{id}_{width}_{height}.jpg` cache key.
+/// Returns `None` for keys of unknown shape, which callers keep.
+fn cache_key_id(key: &str) -> Option<&str> {
+    let base = key.strip_suffix(".jpg")?;
+    let (rest, height) = base.rsplit_once('_')?;
+    let (id, width) = rest.rsplit_once('_')?;
+    if id.is_empty()
+        || !width.chars().all(|c| c.is_ascii_digit())
+        || !height.chars().all(|c| c.is_ascii_digit())
+    {
+        return None;
+    }
+    Some(id)
 }
 
 /// Returns cache statistics as `(file_count, total_bytes)`, skipping `.tmp-` files.
@@ -246,5 +262,24 @@ mod tests {
         assert!(get(&cache, "keep1_10_10.jpg").is_some());
         assert!(get(&cache, "keep1_0_0.jpg").is_some());
         assert_eq!(get(&cache, "gone9_10_10.jpg"), None);
+    }
+    #[test]
+    fn retain_parses_id_from_right_for_underscored_ids() {
+        // GIVEN entries with '_' inside the id and one of unknown shape
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("cache");
+        fs::create_dir_all(&cache).unwrap();
+        put(&cache, "we_ird_10_10.jpg", b"a").unwrap();
+        put(&cache, "plain_10_10.jpg", b"b").unwrap();
+        fs::write(cache.join("oddname.jpg"), b"c").unwrap();
+
+        // WHEN retaining only the underscored id
+        let keep: std::collections::HashSet<String> = ["we_ird".to_string()].into_iter().collect();
+        retain(&cache, &keep).unwrap();
+
+        // THEN the full underscored id is kept, others pruned, unknown kept
+        assert!(get(&cache, "we_ird_10_10.jpg").is_some());
+        assert_eq!(get(&cache, "plain_10_10.jpg"), None);
+        assert!(cache.join("oddname.jpg").exists());
     }
 }

--- a/src/image_cache.rs
+++ b/src/image_cache.rs
@@ -1,5 +1,6 @@
 use parking_lot::Mutex;
 use std::{
+    collections::HashSet,
     fs, io,
     path::{Path, PathBuf},
     time::SystemTime,
@@ -73,17 +74,27 @@ pub fn put(cache_dir: &Path, key: &str, data: &[u8]) -> io::Result<()> {
     evict_if_needed(cache_dir);
     Ok(())
 }
-
-/// Clears all files in the cache directory.
-/// Thread-safe; returns `Ok(())` if the directory does not exist.
-pub fn clear(cache_dir: &Path) -> io::Result<()> {
+/// Removes cached entries whose resource id is not in `keep_ids`.
+/// Cache keys are `{id}_{width}_{height}.jpg`; the id is the part before
+/// the first '_'. Files without '_' or with invalid keys are kept (the LRU
+/// bounds in `put` still apply to them).
+/// Thread-safe via the global mutex; returns `Ok(())` if the directory does not exist.
+pub fn retain(cache_dir: &Path, keep_ids: &HashSet<String>) -> io::Result<()> {
     let _guard = CACHE_MUTEX.lock();
-    if !cache_dir.exists() {
+    let Ok(rd) = fs::read_dir(cache_dir) else {
         return Ok(());
-    }
-    for entry in fs::read_dir(cache_dir)? {
-        let entry = entry?;
-        let _ = fs::remove_file(entry.path());
+    };
+    for entry in rd.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with(".tmp-") || !is_valid_key(&name) {
+            continue;
+        }
+        let Some((id, _)) = name.split_once('_') else {
+            continue;
+        };
+        if !keep_ids.contains(id) {
+            let _ = fs::remove_file(entry.path());
+        }
     }
     Ok(())
 }
@@ -216,5 +227,24 @@ mod tests {
         // THEN no corruption occurred and all entries are present
         assert_eq!(count, 20);
         assert_eq!(bytes, 20 * 100);
+    }
+    #[test]
+    fn retain_removes_only_unknown_ids() {
+        // GIVEN a cache with entries for kept and removed ids
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("cache");
+        fs::create_dir_all(&cache).unwrap();
+        put(&cache, "keep1_10_10.jpg", b"a").unwrap();
+        put(&cache, "keep1_0_0.jpg", b"b").unwrap();
+        put(&cache, "gone9_10_10.jpg", b"c").unwrap();
+
+        // WHEN retaining only keep1
+        let keep: std::collections::HashSet<String> = ["keep1".to_string()].into_iter().collect();
+        retain(&cache, &keep).unwrap();
+
+        // THEN kept entries survive and unknown ids are removed
+        assert!(get(&cache, "keep1_10_10.jpg").is_some());
+        assert!(get(&cache, "keep1_0_0.jpg").is_some());
+        assert_eq!(get(&cache, "gone9_10_10.jpg"), None);
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -56,13 +56,14 @@ pub fn index_resources(resource_reader: ResourceReader, resource_store: Resource
     info!("Purging resources store");
     resource_store.clear_resources();
 
-    info!("Cleanup cache");
+    info!("Pruning image cache entries of removed resources");
     let cache_dir = crate::image_cache::cache_dir(
         &std::env::var("DATA_FOLDER")
             .or_else(|_| std::env::var("CACHE_DIR"))
             .unwrap_or_else(|_| "./data".into()),
     );
-    let _ = crate::image_cache::clear(&cache_dir);
+    let keep_ids: std::collections::HashSet<String> = map.keys().cloned().collect();
+    let _ = crate::image_cache::retain(&cache_dir, &keep_ids);
 
     info!("Inserting new resources");
     resource_store.add_resources(map);


### PR DESCRIPTION
Replace the nightly cache wipe with retain(): only entries whose resource id vanished are pruned. Restart previously wiped 9 warm entries -> 0. HIT stays 15 ms / +0 B vs ~300 ms / +177 MB per MISS. Obsolete clear() removed; retain() covered by new unit test (TDD).

Tests: image_cache 5/5, resources integration 18/18, clippy/fmt clean.